### PR TITLE
fix: resolve bundled CSS with Vite base

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,19 +47,15 @@ const stripLeadingSlash = value => value.startsWith('/') ? value.slice(1) : valu
  * @returns {string}
  */
 const getBundleAssetKey = (href, base) => {
-  let assetKey = stripLeadingSlash(href)
-
   if (!base || base === '/') {
-    return assetKey
+    return stripLeadingSlash(href)
   }
 
-  const normalizedBase = stripLeadingSlash(base)
-
-  if (normalizedBase && assetKey.startsWith(normalizedBase)) {
-    assetKey = stripLeadingSlash(assetKey.slice(normalizedBase.length))
+  if (href.startsWith(base)) {
+    return stripLeadingSlash(href.slice(base.length))
   }
 
-  return assetKey
+  return stripLeadingSlash(href)
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -36,6 +36,33 @@ const findAllNodes = (node, predicate, results = []) => {
 }
 
 /**
+ * @param {string} value
+ * @returns {string}
+ */
+const stripLeadingSlash = value => value.startsWith('/') ? value.slice(1) : value
+
+/**
+ * @param {string} href
+ * @param {string} base
+ * @returns {string}
+ */
+const getBundleAssetKey = (href, base) => {
+  let assetKey = stripLeadingSlash(href)
+
+  if (!base || base === '/') {
+    return assetKey
+  }
+
+  const normalizedBase = stripLeadingSlash(base)
+
+  if (normalizedBase && assetKey.startsWith(normalizedBase)) {
+    assetKey = stripLeadingSlash(assetKey.slice(normalizedBase.length))
+  }
+
+  return assetKey
+}
+
+/**
  * @param {import('@vituum/vite-plugin-juice/types').PluginUserConfig} pluginOptions
  * @returns {import('vite').Plugin}
  */
@@ -85,7 +112,8 @@ const plugin = (pluginOptions = {}) => {
               }
             }
             else {
-              const asset = bundle[href.startsWith('/') ? href.slice(1) : href]
+              const assetKey = getBundleAssetKey(href, resolvedConfig.base)
+              const asset = bundle[assetKey]
               const bundledCss = asset && 'source' in asset ? asset.source : undefined
 
               if (bundledCss) {


### PR DESCRIPTION
## Summary

- normalize build-time stylesheet hrefs before looking them up in the Rollup/Vite bundle
- strip Vite `base` from generated public CSS URLs so `juice` can find assets by bundle key

## Root cause

During build, Vite can rewrite stylesheet links to include `config.base`, for example `/client-app/dist/styles/main.css`. The bundle asset key remains relative, such as `styles/main.css`, so the plugin lookup fails with `TypeError: ... doesn't exists in bundle`.

## Validation

- `npm run lint`
- direct transform check for `/client-app/dist/styles/main.css` resolving to `styles/main.css`
